### PR TITLE
Fix development env for os other than linux

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,13 +5,17 @@ GOBUILD=CGO_ENABLED=0 installsuffix=cgo go build -trimpath
 TOOLS_MOD_DIR = ./internal/tools
 JAEGER_VERSION ?= 1.24.0
 
+TARGET_OS ?= linux
+TARGET_ARCH ?= amd64
+
 .PHONY: build
 build:
 	${GOBUILD} -o jaeger-clickhouse-$(GOOS)-$(GOARCH) ./cmd/jaeger-clickhouse/main.go
+	GOOS=${TARGET_OS} GOARCH=${TARGET_ARCH} ${GOBUILD} -o jaeger-clickhouse-$(TARGET_OS)-$(TARGET_ARCH) ./cmd/jaeger-clickhouse/main.go
 
 .PHONY: run
 run:
-	docker run --rm --name jaeger -e JAEGER_DISABLED=true --link some-clickhouse-server -it -u ${shell id -u} -p16686:16686 -p14250:14250 -p14268:14268 -p6831:6831/udp -v "${PWD}:/data" -e SPAN_STORAGE_TYPE=grpc-plugin jaegertracing/all-in-one:${JAEGER_VERSION} --query.ui-config=/data/jaeger-ui.json --grpc-storage-plugin.binary=/data/jaeger-clickhouse-$(GOOS)-$(GOARCH) --grpc-storage-plugin.configuration-file=/data/config.yaml --grpc-storage-plugin.log-level=debug
+	docker run --rm --name jaeger -e JAEGER_DISABLED=true --link some-clickhouse-server -it -u ${shell id -u} -p16686:16686 -p14250:14250 -p14268:14268 -p6831:6831/udp -v "${PWD}:/data" -e SPAN_STORAGE_TYPE=grpc-plugin jaegertracing/all-in-one:${JAEGER_VERSION} --query.ui-config=/data/jaeger-ui.json --grpc-storage-plugin.binary=/data/jaeger-clickhouse-$(TARGET_OS)-$(TARGET_ARCH) --grpc-storage-plugin.configuration-file=/data/config.yaml --grpc-storage-plugin.log-level=debug
 
 .PHONY: run-hotrod
 run-hotrod:


### PR DESCRIPTION
Docker container expect linux binaries. We are always looking for GOOS and GOARCH which will be different in macos hence it will fail with /data/jaeger-clickhouse-darwin-amd64: exec format error

On OSX:
```
❯ make run
docker run --rm --name jaeger -e JAEGER_DISABLED=true --link some-clickhouse-server -it -u 502 -p16686:16686 -p14250:14250 -p14268:14268 -p6831:6831/udp -v "/Users/pradeep/gh/jaeger-clickhouse:/data" -e SPAN_STORAGE_TYPE=grpc-plugin jaegertracing/all-in-one:1.24.0 --query.ui-config=/data/jaeger-ui.json --grpc-storage-plugin.binary=/data/jaeger-clickhouse-darwin-amd64 --grpc-storage-plugin.configuration-file=/data/config.yaml --grpc-storage-plugin.log-level=debug
2021/07/17 04:44:26 maxprocs: Leaving GOMAXPROCS=6: CPU quota undefined
{"level":"info","ts":1626497066.4456441,"caller":"flags/service.go:117","msg":"Mounting metrics handler on admin server","route":"/metrics"}
{"level":"info","ts":1626497066.445714,"caller":"flags/service.go:123","msg":"Mounting expvar handler on admin server","route":"/debug/vars"}
{"level":"info","ts":1626497066.4459236,"caller":"flags/admin.go:105","msg":"Mounting health check on admin server","route":"/"}
{"level":"info","ts":1626497066.445999,"caller":"flags/admin.go:111","msg":"Starting admin HTTP server","http-addr":":14269"}
{"level":"info","ts":1626497066.446192,"caller":"flags/admin.go:97","msg":"Admin server started","http.host-port":"[::]:14269","health-status":"unavailable"}
2021-07-17T04:44:26.446Z [DEBUG] starting plugin: path=/data/jaeger-clickhouse-darwin-amd64 args=["/data/jaeger-clickhouse-darwin-amd64", "--config", "/data/config.yaml"]
{"level":"fatal","ts":1626497066.4515028,"caller":"command-line-arguments/main.go:103","msg":"Failed to init storage factory","error":"grpc-plugin builder failed to create a store: error attempting to connect to plugin rpc cl
ient: fork/exec /data/jaeger-clickhouse-darwin-amd64: exec format error","stacktrace":"main.main.func1\n\tcommand-line-arguments/main.go:103\ngithub.com/spf13/cobra.(*Command).execute\n\tgithub.com/spf13/cobra@v0.0.7/command.
go:838\ngithub.com/spf13/cobra.(*Command).ExecuteC\n\tgithub.com/spf13/cobra@v0.0.7/command.go:943\ngithub.com/spf13/cobra.(*Command).Execute\n\tgithub.com/spf13/cobra@v0.0.7/command.go:883\nmain.main\n\tcommand-line-argument
s/main.go:216\nruntime.main\n\truntime/proc.go:225"}
```

Signed-off-by: Pradeep Chhetri <pradeepchhetri4444@gmail.com>