### PR TITLE
Remove tls config options

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -7,9 +7,7 @@ batch_write_size:
 batch_flush_interval:
 # Encoding of stored data. Either json or protobuf. Default json.
 encoding:
-# Whether to use TLS connection. Default false.
-tls_connection:
-# Address of TLS certificate.
+# Path to CA TLS certificate.
 ca_file:
 # Username for connection. Default is "default".
 username:

--- a/storage/config.go
+++ b/storage/config.go
@@ -29,8 +29,6 @@ type Configuration struct {
 	Address string `yaml:"address"`
 	// Directory with .sql files that are run at plugin startup.
 	InitSQLScriptsDir string `yaml:"init_sql_scripts_dir"`
-	// Indicates whether to use TLS
-	TLSConnection bool `yaml:"tls_connection"`
 	// Indicates location of TLS certificate used to connect to database.
 	CaFile string `yaml:"ca_file"`
 	// Username for connection to database. Default is "default".

--- a/storage/store.go
+++ b/storage/store.go
@@ -66,7 +66,7 @@ func connector(cfg Configuration) (*sql.DB, error) {
 		cfg.Password,
 	)
 
-	if cfg.TLSConnection {
+	if cfg.CaFile != "" {
 		caCert, err := ioutil.ReadFile(cfg.CaFile)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
Signed-off-by: Pavol Loffay <p.loffay@gmail.com>


The config property is not needed it can be derived from CA path.

cc) @EinKrebs
